### PR TITLE
Include source files in package releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning][semver].
 ### Changed
 - Rename test files to use `test` instead of `spec`.
 
+### Fixed
+- Include TypeScript source files in package releases. Release [0.2.0] added
+source maps, but they are useless without source files.
+
 ## [0.2.0] - 2023-03-14
 ### Added
 - Source maps are now generated and included.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "!lib/**/*.test.js.map",
     "types/",
     "!types/**/*.test.d.ts",
+    "src/",
+    "!src/**/*.test.ts",
     "CHANGELOG.md",
     "SECURITY.md"
   ],


### PR DESCRIPTION
Commit e01114776c584213c4ee94a75317658b06835e23 added source maps, however, it did not also change the `package.json` `files` property to include the original TypeScript source files. Source maps are nothing without source files, so this commit adds them to the `files` property.