### PR TITLE
Add ownKeys, getOwnPropertyDescriptor to proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+### Added
+- Support for the following `Object` static methods:
+  - `keys`
+  - `values`
+  - `entries`
+  - `getOwnPropertyNames`
+  - `getOwnPropertyDescriptor`
+  - `getOwnPropertyDescriptors`
+
 ## [0.3.0] - 2023-03-16
 ### Added
 - "Features" section to README.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ for Node.js.
 - Supports `setItem`, `getItem`, `deleteItem`, `clear`, and `key` methods.
 - Supports `length` property.
 - Supports dot and bracket property accessors.
+- Supports `Object.keys`, `Object.values`, and `Object.entries` static methods.
 - Small footprint with zero dependencies.
 - TypeScript declarations.
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -213,3 +213,87 @@ test.serial(
     t.is(typeof nsStorage["setItem"], "function");
   }
 );
+
+test.serial("NamespacedStorage - Object.keys", (t) => {
+  t.context.storage.setItem("foo:user-id", "1234");
+  t.context.storage.setItem("banner-closed", "true");
+  t.context.storage.setItem("foo:preferred-theme", "dark");
+
+  const nsStorage = new NamespacedStorage(t.context.storage, "foo");
+
+  t.deepEqual(Object.keys(nsStorage), ["user-id", "preferred-theme"]);
+});
+
+test.serial("NamespacedStorage - Object.values", (t) => {
+  t.context.storage.setItem("foo:user-id", "1234");
+  t.context.storage.setItem("banner-closed", "true");
+  t.context.storage.setItem("foo:preferred-theme", "dark");
+
+  const nsStorage = new NamespacedStorage(t.context.storage, "foo");
+
+  t.deepEqual(Object.values(nsStorage), ["1234", "dark"]);
+});
+
+test.serial("NamespacedStorage - Object.entries", (t) => {
+  t.context.storage.setItem("foo:user-id", "1234");
+  t.context.storage.setItem("banner-closed", "true");
+  t.context.storage.setItem("foo:preferred-theme", "dark");
+
+  const nsStorage = new NamespacedStorage(t.context.storage, "foo");
+
+  t.deepEqual(Object.entries(nsStorage), [
+    ["user-id", "1234"],
+    ["preferred-theme", "dark"],
+  ]);
+});
+
+test.serial("NamespacedStorage - Object.getOwnPropertyNames", (t) => {
+  t.context.storage.setItem("foo:user-id", "1234");
+  t.context.storage.setItem("banner-closed", "true");
+  t.context.storage.setItem("foo:preferred-theme", "dark");
+
+  const nsStorage = new NamespacedStorage(t.context.storage, "foo");
+
+  t.deepEqual(Object.getOwnPropertyNames(nsStorage), [
+    "user-id",
+    "preferred-theme",
+  ]);
+});
+
+test.serial("NamespacedStorage - Object.getOwnPropertyDescriptor", (t) => {
+  t.context.storage.setItem("foo:user-id", "1234");
+  t.context.storage.setItem("banner-closed", "true");
+  t.context.storage.setItem("foo:preferred-theme", "dark");
+
+  const nsStorage = new NamespacedStorage(t.context.storage, "foo");
+
+  t.deepEqual(Object.getOwnPropertyDescriptor(nsStorage, "preferred-theme"), {
+    configurable: true,
+    enumerable: true,
+    value: "dark",
+    writable: true,
+  });
+});
+
+test.serial("NamespacedStorage - Object.getOwnPropertyDescriptors", (t) => {
+  t.context.storage.setItem("foo:user-id", "1234");
+  t.context.storage.setItem("banner-closed", "true");
+  t.context.storage.setItem("foo:preferred-theme", "dark");
+
+  const nsStorage = new NamespacedStorage(t.context.storage, "foo");
+
+  t.deepEqual(Object.getOwnPropertyDescriptors(nsStorage), {
+    "user-id": {
+      configurable: true,
+      enumerable: true,
+      value: "1234",
+      writable: true,
+    },
+    "preferred-theme": {
+      configurable: true,
+      enumerable: true,
+      value: "dark",
+      writable: true,
+    },
+  });
+});


### PR DESCRIPTION
These two handler methods allows `NamespacedStorage` to be used with various `Object` static methods, like `keys`, `values` and `entries`.

Since the proxy handler is no longer specific to property accessor notations, it is renamed to a more generic `proxyHandler`.