### PR TITLE
Add validation for `prefix` constructor argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog][keep_a_changelog],
 and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
+### Added
+- Assertion for `prefix` constructor argument. The constructor will now throw if
+the `prefix` is not a non-empty string.
+
 ### Changed
 - Upgrade `lint-staged` from `13.2.0` to `13.2.2`.
 - Upgrade `prettier` from `2.8.4` to `2.8.8`.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -36,6 +36,49 @@ test.serial("NamespacedStorage - constructor", (t) => {
   t.notThrows(() => new NamespacedStorage(t.context.storage, "foo"));
 });
 
+const invalidPrefixTestValues = [
+  {
+    prefix: undefined,
+    errorMessage: 'Prefix is of type "undefined", expected "string".',
+  },
+  {
+    prefix: true,
+    errorMessage: 'Prefix is of type "boolean", expected "string".',
+  },
+  {
+    prefix: null,
+    errorMessage: 'Prefix is of type "object", expected "string".',
+  },
+  {
+    prefix: 1234,
+    errorMessage: 'Prefix is of type "number", expected "string".',
+  },
+  {
+    prefix: {},
+    errorMessage: 'Prefix is of type "object", expected "string".',
+  },
+  {
+    prefix: "",
+    errorMessage:
+      "Prefix cannot be an empty string or composed of only whitespaces.",
+  },
+  {
+    prefix: "    ",
+    errorMessage:
+      "Prefix cannot be an empty string or composed of only whitespaces.",
+  },
+];
+invalidPrefixTestValues.forEach(({ prefix, errorMessage }) => {
+  test.serial(
+    `NamespacedStorage - constructor - throws on invalid prefix (${prefix})`,
+    (t) => {
+      t.throws(() => new NamespacedStorage(t.context.storage, prefix as any), {
+        message: errorMessage,
+      });
+    }
+  );
+});
+
 test.serial("NamespacedStorage - setItem", (t) => {
   const nsStorage = new NamespacedStorage(t.context.storage, "foo");
   nsStorage.setItem("user-id", "1234");

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,18 @@ const isKeyPrefixed = (key: string, prefix: string): boolean => {
   return key.startsWith(prefix + PREFIX_SEPARATOR);
 };
 
+const assertPrefixIsValid = (prefix: unknown): void => {
+  if (typeof prefix !== "string") {
+    throw new Error(`Prefix is of type "${typeof prefix}", expected "string".`);
+  }
+
+  if (prefix.trim().length === 0) {
+    throw new Error(
+      "Prefix cannot be an empty string or composed of only whitespaces."
+    );
+  }
+};
+
 const RESERVED_PROPERTIES = [
   // Storage properties
   "length",
@@ -126,6 +138,7 @@ export class NamespacedStorage implements Storage {
    * `prefix` to create a namespace for keys.
    */
   constructor(private storage: Storage, private prefix: string) {
+    assertPrefixIsValid(prefix);
     return new Proxy(this, proxyHandler);
   }
 


### PR DESCRIPTION
This PR adds an assertion for the `prefix` constructor argument. The constructor will now throw if the `prefix` is not a non-empty string.