### PR TITLE
Change publish workflow to use dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,12 @@
 name: Publish
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      git_tag:
+        description: "Git tag to publish"
+        required: true
+        type: string
 
 jobs:
   publish-npm:
@@ -11,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: refs/tags/${{ inputs.git_tag }}
 
       - name: Setup Node.js 18
         uses: actions/setup-node@v3


### PR DESCRIPTION
The release 'published' trigger doesn't seem to work, so revert to the original idea of using `workflow_dispatch` with a git tag input.